### PR TITLE
Fix latest release link

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -32,6 +32,6 @@ matter = "evaera/matter@X.X.X" # Don't copy this. This won't work.
 
 ## Manual
 
-1. Download `matter.rbxm` from the [latest release](https://github.com/UpliftGames/moonwave/releases/latest).
+1. Download `matter.rbxm` from the [latest release](https://github.com/evaera/matter/releases/latest).
 2. Sync in with [Rojo](https://rojo.space) or import into Roblox Studio manually.
 


### PR DESCRIPTION
The link originally pointed to the wrong location (https://github.com/UpliftGames/moonwave/releases/latest) when it seemingly meant to point to the latest release of this repo.