### PR TITLE
Fix mismatching components.lua name in GettingStarted

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -63,7 +63,7 @@ return {
 Let's make a system that removes 0.1 health every frame from things that are poisoned.
 
 ```lua title="systems/poisonHurts.lua"
-local Components = require(script.Parent.Components)
+local Components = require(script.Parent.components)
 local Health = Components.Health
 local Poison = Components.Poison
 


### PR DESCRIPTION
In Getting Started, we use the title `components.lua`, but then require it in `system/poisonHurts.lua` as `script.Parent.Components`.

Components should've been lowercase.