### PR TITLE
Correct system error stacktraces

### DIFF
--- a/lib/Loop.lua
+++ b/lib/Loop.lua
@@ -309,6 +309,7 @@ function Loop:begin(events)
 						end
 
 						local errorString = systemName(system) .. ": " .. tostring(errorValue)
+						.. "\n" .. debug.traceback(thread)
 
 						if not recentErrors[errorString] then
 							task.spawn(error, errorString)


### PR DESCRIPTION
Before this change, stacktraces of errors in systems would be truncated.
```lua
local function third(argument)
    argument += 1
end

local function second()
    third({})
end

local function first()
    second()
end

local function system(world)
    first()
end

return system
```

```
ServerScriptService.Game.systems.system->system: ServerScriptService.Game.systems.system:2: attempt to perform arithmetic (add) on table and number  -  Server
  12:49:43.023  Stack Begin  -  Studio
  12:49:43.023  Stack End  -  Studio
  12:49:43.023  Matter: The above error will be suppressed for the next 10 seconds  - 
```

This expands them.

```
ServerScriptService.Game.systems.system->system: ServerScriptService.Game.systems.system:2: attempt to perform arithmetic (add) on table and number
ServerScriptService.Game.systems.system:2 function third
ServerScriptService.Game.systems.system:6 function second
ServerScriptService.Game.systems.system:10 function first
ServerScriptService.Game.systems.system:14 function system
```