### PR TITLE
Store Entire Change Between queryChanged Calls

### DIFF
--- a/lib/World.lua
+++ b/lib/World.lua
@@ -594,7 +594,14 @@ function World:_trackChanged(metatable, id, old, new)
 	})
 
 	for _, storage in ipairs(self._changedStorage[metatable]) do
-		storage[id] = record
+		if (storage[id]) then
+			storage[id] = table.freeze({
+				old = storage[id].old,
+				new = new,
+			})
+		else 
+			storage[id] = record
+		end
 	end
 end
 

--- a/lib/World.lua
+++ b/lib/World.lua
@@ -594,14 +594,7 @@ function World:_trackChanged(metatable, id, old, new)
 	})
 
 	for _, storage in ipairs(self._changedStorage[metatable]) do
-		if (storage[id]) then
-			storage[id] = table.freeze({
-				old = storage[id].old,
-				new = new,
-			})
-		else 
-			storage[id] = record
-		end
+		storage[id] = if storage[id] then table.freeze({ old = storage[id].old, new = new, }) else record 
 	end
 end
 

--- a/lib/World.lua
+++ b/lib/World.lua
@@ -594,7 +594,14 @@ function World:_trackChanged(metatable, id, old, new)
 	})
 
 	for _, storage in ipairs(self._changedStorage[metatable]) do
-		storage[id] = if storage[id] then table.freeze({ old = storage[id].old, new = new, }) else record 
+		-- If this entity has changed since the last time this system read it,
+		-- we ensure that the "old" value is whatever the system saw it as last, instead of the
+		-- "old" value we have here.
+		if storage[id] then
+			storage[id] = table.freeze({ old = storage[id].old, new = new })
+		else
+			storage[id] = record
+		end
 	end
 end
 

--- a/lib/World.spec.lua
+++ b/lib/World.spec.lua
@@ -270,11 +270,20 @@ return function()
 					if count == 0 then
 						expect(infrequentCount).to.equal(1)
 					else
-						expect(infrequentCount).to.equal(2)
-						expect(count).to.equal(2)
+						if infrequentCount == 2 then
+							expect(count).to.equal(2)
 
-						expect(results[0].old.generation).to.equal(2)
-						expect(results[1].old.generation).to.equal(1)
+							expect(results[0].old).to.equal(nil)
+							expect(results[0].new.generation).to.equal(2)
+							expect(results[1].old).to.equal(nil)
+							expect(results[1].new).to.equal(nil)
+						elseif infrequentCount == 3 then
+							expect(results[0].old.generation).to.equal(2)
+							expect(results[0].new).to.equal(nil)
+							expect(count).to.equal(1)
+						else
+							error("infrequentCount too high")
+						end
 					end
 				end,
 				event = "infrequent",
@@ -324,6 +333,8 @@ return function()
 			defaultBindable:Fire()
 
 			world:replace(secondEntityId, B())
+
+			infrequentBindable:Fire()
 
 			world:despawn(entityId)
 


### PR DESCRIPTION
Example:

in runtime.server.ts after starting the loop:
```ts
task.spawn(() => {
    task.wait(1);
    for (let i = 0; i < 10; i++) {
        world.spawn(TestComponent({ value: 0 }));
    }
});
```

TestSystem1:
```ts
export = (world: World) => {
    // check for newly added Test Components -- does print "ADDED"
    for (const [entity, testComponentRecord] of world.queryChanged(TestComponent)) {
        if (!testComponentRecord.old) {
            print("ADDED");
        }
    }
    
    // increment all TestComponents by one -- this change modifies the TestComponentRecord for the TestSystem2
    const TestComponents: [Entity<[TestComponent]>, TestComponent][] = [];
    for (const [entity, testComponent] of world.query(TestComponent)) {
        TestComponents.push([entity, testComponent]);
    }
    for (const [entity, testComponent] of TestComponents) {
        world.insert(entity, testComponent.patch({ value: testComponent.value + 1 }));
    }
};
```

TestSystem2:
```ts
export = {
    priority: math.huge,
    system: (world: World) => {
        // check for newly added Test Components -- does NOT print "ADDED #2"
        for (const [entity, testComponentRecord] of world.queryChanged(TestComponent)) {
            if (!testComponentRecord.old) {
                print("ADDED #2");
            }
        }
    },
};
```

Currently:
-> record: {old: nil, new: {value: 0}}
-> that record goes into TestSystem1
-> ADDED1 prints, TestSystem1 increments value
-> record: {old: {value: 0}, new: {value: 1 }}
-> this record goes into TestSystem2

With Change:
-> record for TestSystem1: {old: nil, new: {value: 0}}
-> that record goes into TestSystem1
-> ADDED1 prints, TestSystem1 increments value
-> record for TestSystem2: {old: nil, new: {value: 1 }}
-> this record goes into TestSystem2
-> ADDED2 prints

I think this is best because you shouldn't have to look through every system to understand if your queryChanged will detect when a component is added.