### PR TITLE
Fix comments on structure of `_archetypes` and `_entityArchetypes`

### DIFF
--- a/lib/World.lua
+++ b/lib/World.lua
@@ -21,10 +21,10 @@ World.__index = World
 ]=]
 function World.new()
 	return setmetatable({
-		-- Map from entity ID -> archetype string
+		-- Map from archetype string --> entity ID --> entity data
 		_archetypes = {},
 
-		-- Map from archetype string --> entity ID --> entity data
+		-- Map from entity ID -> archetype string
 		_entityArchetypes = {},
 
 		-- Cache of the component metatables on each entity. Used for generating archetype.


### PR DESCRIPTION
The comments associated with `_archetypes` and `_entityArchetypes` are improperly assigned and, as such, flipped. The appropriate comments are swapped between the two. This PR just changes that to better reflect how these tables are used internally.