### PR TITLE
Debugger supports events that aren't fired consistently

### DIFF
--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -149,6 +149,12 @@ local function ui(debugger, loop)
 			end
 		end)
 
+		if debugger.debugSystem and typeof(debugger.debugSystem) == "table" then
+			if not debugger._lastFrame[debugger.debugSystem.event] then
+				debugger.debugSystem = nil
+			end
+		end
+
 		debugger.parent = custom.container(function()
 			if worldView then
 				local closed = plasma.window({

--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -96,7 +96,7 @@ local function ui(debugger, loop)
 			plasma.heading("SYSTEMS")
 			plasma.space(10)
 
-			for _, eventName in debugger._eventOrder do
+			for eventName in debugger._lastFrame do
 				local systems = loop._orderedSystemsByEvent[eventName]
 
 				if not systems then

--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -150,7 +150,8 @@ local function ui(debugger, loop)
 		end)
 
 		if debugger.debugSystem and typeof(debugger.debugSystem) == "table" then
-			if not debugger._lastFrame[debugger.debugSystem.event] then
+			local eventName = debugger.debugSystem.event
+			if eventName and not debugger._lastFrame[eventName] then
 				debugger.debugSystem = nil
 			end
 		end


### PR DESCRIPTION
Currently, event order is determined as events are added and it's assumed to stay the same. This means that events that _don't_ fire consistently keep the debugger from running.

For example, if you have a _Startup_ event that fires once before your other events, it will keep the debugger from continuing as it still expects the _Startup_ event to be in `_eventOrder` position 1. In this specific instance, you can move any "Startup" systems outside of your loop, but it serves to highlight the issue.

The changed logic keeps a record of the events it has seen for the current loop (`_currentFrame`) and stops once it encounters a repeat. It then finishes the frame, sets `_continueHandle` to nil, stores the record (as `_lastFrame`) so that `ui.lua` can still access it, and resets the current record. A new frame begins if `_continueHandle` is nil.