### PR TITLE
Suggest compatible Plasma in debugger docs

### DIFF
--- a/docs/Guides/MatterDebugger.md
+++ b/docs/Guides/MatterDebugger.md
@@ -37,7 +37,7 @@ You need to install [Plasma](https://eryn.io/plasma/) as a dependency to your pr
 
 ```toml title="wally.toml"
 [dependencies]
-plasma = "evaera/plasma@0.2.0"
+plasma = "evaera/plasma@0.4.0"
 ```
 
 ### Create the debugger


### PR DESCRIPTION
Ran into this issue following the docs. Bumping the version of Plasma to match the one in the example project.