### PR TITLE
Add caution tip for autoInitialize docs

### DIFF
--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -254,6 +254,10 @@ end
 	:::tip
 	The debugger must also be shown on a client with [Debugger:show] or [Debugger:toggle] to be used.
 	:::
+						
+	:::caution
+	[Debugger:autoInitialize] should be called before [Loop:begin] to function as expected.
+	:::
 
 	If you also want to use Plasma for more than just the debugger, you can opt to not call this function and instead
 	do what it does yourself.


### PR DESCRIPTION
Ran into this issue attempt to use the debugger. Perhaps there's a better way to announce this warning. Having something like this would have saved me a bit of time and is probably a good start.