### PR TITLE
Error when component instance accidentally passed

### DIFF
--- a/lib/component.lua
+++ b/lib/component.lua
@@ -115,7 +115,7 @@ local function newComponent(name, defaultData)
 	return component
 end
 
-local function assertValidComponent(value, position)
+local function assertValidComponent(value, position, ignoreMissingMarker)
 	if typeof(value) ~= "table" then
 		error(string.format("Component #%d is invalid: not a table", position), 3)
 	end
@@ -125,10 +125,18 @@ local function assertValidComponent(value, position)
 	if metatable == nil then
 		error(string.format("Component #%d is invalid: has no metatable", position), 3)
 	end
+	
+	if ignoreMissingMarker ~= true and metatable[DIAGNOSTIC_COMPONENT_MARKER] == nil then
+		if getmetatable(metatable)[DIAGNOSTIC_COMPONENT_MARKER] == true then
+			error(string.format("Component #%d is invalid: accidentally passed Component instance", position), 3)
+		else
+			error(string.format("Component #%d is invalid: not a Component", position), 3)
+		end
+	end
 end
 
 local function assertValidComponentInstance(value, position)
-	assertValidComponent(value, position)
+	assertValidComponent(value, position, true)
 
 	if getmetatable(value)[DIAGNOSTIC_COMPONENT_MARKER] ~= nil then
 		error(


### PR DESCRIPTION
Previously, Component instances could be passed where they don't belong without warning/error.
* Added a check to error when component instances are inadvertently passed __directly__ to `assertValidComponent`.