### PR TITLE
More flexible dependencies

### DIFF
--- a/lib/Loop.lua
+++ b/lib/Loop.lua
@@ -255,8 +255,23 @@ local function orderSystemsByDependencies(unscheduledSystems: { System })
 			if type(system) == "table" and system.after then
 				for _, dependency in ipairs(system.after) do
 					if scheduledSystemsSet[dependency] == nil then
-						allScheduled = false
-						break
+						if type(dependency) == "table" then
+							allScheduled = false
+							break
+						elseif type(dependency) == "function" then
+							local wasDependencyFound = false
+							for _, scheduledSystem in ipairs(scheduledSystems) do
+								if type(scheduledSystem) == "table" and scheduledSystem.system == dependency then
+									wasDependencyFound = true
+									break
+								end
+							end
+
+							if not wasDependencyFound then
+								allScheduled = false
+								break
+							end
+						end
 					end
 				end
 			end
@@ -348,7 +363,7 @@ function Loop:begin(events)
 
 			generation = not generation
 
-			local dirtyWorlds: {[any]: true} = {}
+			local dirtyWorlds: { [any]: true } = {}
 			local profiling = self.profiling
 
 			for _, system in ipairs(self._orderedSystemsByEvent[eventName]) do


### PR DESCRIPTION
When scheduling systems with chains of dependencies, you need to keep a references to the system structs:

```lua
local systemBStruct = {
	system = systemB,
	after = { systemA }
}

local systemCStruct = {
	system = systemC,
	after = { systemBStruct }
}

loop:scheduleSystems({
	systemA,
	systemBStruct,
	systemCStruct,
	{
		system = systemD,
		after = { systemCStruct }
	}
})
```
That's kind of inconvenient (and also isn't documented anywhere, and also wasn't how I would expect this API to work!), so this change makes it such that you can just use the function, instead of the struct:
```lua
loop:scheduleSystems({
	systemA,
	{
		system = systemB,
		after = { systemA },
	},
	{
		system = systemC,
		after = { systemB },
	},
	{
		system = systemD,
		after = { systemC },
	},
})
```