### PR TITLE
Add in Luau typings, improve docs and ensure exported Matter object is read only

### DIFF
--- a/lib/hooks/log.lua
+++ b/lib/hooks/log.lua
@@ -36,8 +36,6 @@ local function log(...)
 	if #state.logs > 100 then
 		table.remove(state.logs, 1)
 	end
-
-	return state.deltaTime
 end
 
 return log

--- a/lib/hooks/useThrottle.lua
+++ b/lib/hooks/useThrottle.lua
@@ -36,7 +36,7 @@ end
 	@param discriminator? any -- A unique value to additionally key by
 	@return boolean -- returns true every x seconds, otherwise false
 ]=]
-local function useThrottle(seconds, discriminator)
+local function useThrottle(seconds: number, discriminator: any)
 	local storage = topoRuntime.useHookState(discriminator, cleanup)
 
 	if storage.time == nil or os.clock() - storage.time >= seconds then

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -61,7 +61,7 @@ local topoRuntime = require(script.topoRuntime)
 export type World = typeof(World.new())
 export type Loop = typeof(Loop.new())
 
-return {
+return table.freeze({
 	World = World,
 	Loop = Loop,
 
@@ -78,4 +78,4 @@ return {
 	None = immutable.None,
 
 	Debugger = require(script.debugger.debugger),
-}
+})


### PR DESCRIPTION
The PR includes:

- Luau Typings for `useEvent` and `useThrottle`.
- Documentation improvements for `useEvent`.
- Freezing the exported Matter object via `table.freeze`.
- Removing redundant return value from `Matter.log` 