### PR TITLE
Ensure exported matter object is read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## Unreleased
-
-#### Added
+### Changed
 
 - Exported Matter object is now read only, which prevents invalid mutations to it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### Added
+
+- Exported Matter object is now read only, which prevents invalid mutations to it.
+
 ## [0.6.2] - 2022-07-22
 ### Fixed
 - Debugger no longer interferes with `queryChanged` in order to display it in the debugger view. Previously, this caused the storage to get reset. This feature may return in the future.

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -61,7 +61,7 @@ local topoRuntime = require(script.topoRuntime)
 export type World = typeof(World.new())
 export type Loop = typeof(Loop.new())
 
-return {
+return table.freeze({
 	World = World,
 	Loop = Loop,
 
@@ -78,4 +78,4 @@ return {
 	None = immutable.None,
 
 	Debugger = require(script.debugger.debugger),
-}
+})


### PR DESCRIPTION
This PR ensures that the exported Matter object is read-only, which prevents invalid mutations to it