### PR TITLE
Change `Matter.log` to return nothing as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changed
 
+- Change `Matter.log` to return *nothing* as expected.
 - Exported Matter object is now read only, which prevents invalid mutations to it.
 
 ## [0.6.2] - 2022-07-22

--- a/lib/hooks/log.lua
+++ b/lib/hooks/log.lua
@@ -36,8 +36,6 @@ local function log(...)
 	if #state.logs > 100 then
 		table.remove(state.logs, 1)
 	end
-
-	return state.deltaTime
 end
 
 return log


### PR DESCRIPTION
`Matter.log` for some reason returns `state.deltaTime` (which is not specified at all and is redundant anyways) - this PR gets rid of the redundant return value.