### PR TITLE
Change `topoRunTime.useCurrentSystem` to return an explicit `nil` value

### DIFF
--- a/lib/topoRuntime.lua
+++ b/lib/topoRuntime.lua
@@ -46,7 +46,7 @@ end
 
 local function useCurrentSystem()
 	if #stack == 0 then
-		return
+		return nil 
 	end
 
 	return stack[#stack].node.currentSystem


### PR DESCRIPTION
Ensure `topoRunTime.useCurrentSystem` returns an explicit `nil` value, instead of *nothing* at all.