### PR TITLE
Improve error message when a component instance is accidentally passed instead of a component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change `Matter.log` to return *nothing* as expected.
 - Exported Matter object is now read only, which prevents invalid mutations to it.
 - Improve documentation for `Matter.useEvent`.
+- Improve error message for when a component instance is passed where a component is expected, e.g `world:remove(id, componentInstance())`.
 
 ## [0.6.2] - 2022-07-22
 ### Fixed

--- a/lib/component.lua
+++ b/lib/component.lua
@@ -115,7 +115,7 @@ local function newComponent(name, defaultData)
 	return component
 end
 
-local function assertValidComponent(value, position)
+local function assertValidType(value, position)
 	if typeof(value) ~= "table" then
 		error(string.format("Component #%d is invalid: not a table", position), 3)
 	end
@@ -127,8 +127,25 @@ local function assertValidComponent(value, position)
 	end
 end
 
+local function assertValidComponent(value, position)
+	assertValidType(value, position)
+
+	local metatable = getmetatable(value)
+
+	if getmetatable(metatable) ~= nil and getmetatable(metatable)[DIAGNOSTIC_COMPONENT_MARKER] then
+		error(
+			string.format(
+				"Component #%d is invalid: component instance of component %s was passed instead of the component it self!",
+				position,
+				tostring(metatable)
+			),
+			3
+		)
+	end
+end
+
 local function assertValidComponentInstance(value, position)
-	assertValidComponent(value, position)
+	assertValidType(value, position)
 
 	if getmetatable(value)[DIAGNOSTIC_COMPONENT_MARKER] ~= nil then
 		error(

--- a/lib/component.spec.lua
+++ b/lib/component.spec.lua
@@ -2,6 +2,7 @@ local Component = require(script.Parent.component)
 local None = require(script.Parent.immutable).None
 local component = Component.newComponent
 local assertValidComponentInstance = Component.assertValidComponentInstance
+local assertValidComponent = Component.assertValidComponent
 
 return function()
 	describe("Component", function()
@@ -82,6 +83,22 @@ return function()
 
 			expect(function()
 				assertValidComponentInstance(component().new())
+			end).never.to.throw()
+		end)
+	end)
+
+	describe("assertValidComponent", function()
+		it("should throw on invalid components", function()
+			expect(function()
+				assertValidComponent(component().new())
+			end).to.throw()
+
+			expect(function()
+				assertValidComponent(55)
+			end).to.throw()
+
+			expect(function()
+				assertValidComponent(component())
 			end).never.to.throw()
 		end)
 	end)


### PR DESCRIPTION
Closes down #28.