### PR TITLE
Update Rojo's version to 7.2.1 to mitigate attribute error

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -1,3 +1,3 @@
 [tools]
 wally = "upliftgames/wally@0.3.1"
-rojo = "rojo-rbx/rojo@7.1.1"
+rojo = "rojo-rbx/rojo@7.2.1"


### PR DESCRIPTION
It's my first time using Matter and I was attempting to serve the `example.project.json` and then sync with it during my Studio instance. There was an attribute issue that was disabling me from syncing with the Rojo connection.

The error is as follows:
![image](https://user-images.githubusercontent.com/75750304/200358846-0dec3909-dd7b-497f-b197-6b2de28c6b21.png)

I noticed that the Rojo version within `aftman.toml` was outdated, so I updated it in this fork. I can confirm that this fixed my issue with the error and can now sync as expected. Anybody who's new to using Matter shouldn't run into this issue any longer.

Thanks.