### PR TITLE
Cleanup example game's codebase

### DIFF
--- a/example/src/server/systems/mothershipsSpawnRoombas.lua
+++ b/example/src/server/systems/mothershipsSpawnRoombas.lua
@@ -1,4 +1,3 @@
-local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
 local Matter = require(ReplicatedStorage.Lib.Matter)

--- a/example/src/server/systems/roombasMove.lua
+++ b/example/src/server/systems/roombasMove.lua
@@ -1,6 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
-local Matter = require(ReplicatedStorage.Lib.Matter)
 
 local function roombasMove(world)
 	local targets = {}

--- a/example/src/server/systems/spawnMotherships.lua
+++ b/example/src/server/systems/spawnMotherships.lua
@@ -1,4 +1,3 @@
-local ServerScriptService = game:GetService("ServerScriptService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
 local Matter = require(ReplicatedStorage.Lib.Matter)

--- a/example/src/server/systems/spawnRoombas.lua
+++ b/example/src/server/systems/spawnRoombas.lua
@@ -1,6 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Components = require(ReplicatedStorage.Shared.components)
-local Matter = require(ReplicatedStorage.Lib.Matter)
 
 local function spawnRoombas(world)
 	for id, transform in world:query(Components.Transform, Components.Roomba):without(Components.Model) do


### PR DESCRIPTION
Get rid of unused variables in some files in the example game codebase to clear up Luau LSP warnings.