### PR TITLE
Debugger Appears Above Ingame UI

### DIFF
--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -317,6 +317,7 @@ function Debugger:autoInitialize(loop)
 
 	local parent = Instance.new("ScreenGui")
 	parent.Name = "MatterDebugger"
+	parent.DisplayOrder = 2 ^ 31 - 1
 	parent.ResetOnSpawn = false
 	parent.IgnoreGuiInset = true
 


### PR DESCRIPTION
Matter debugger can sometimes collide with ingame HUD elements (blanked out in this screenshot for proprietary reasons)
<img width="348" alt="image" src="https://user-images.githubusercontent.com/122126644/211610172-5e9dfa33-221e-43f6-b6cd-24ceba3c8006.png">

This PR changes the DisplayOrder of the matter debugger to appear above any in-game HUD elements.