### PR TITLE
Fix incorrect `middleware` parameter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change `Matter.log` to return *nothing* as expected.
 - Exported Matter object is now read only, which prevents invalid mutations to it.
 - Improve documentation for `Matter.useEvent`.
+- Fix incorrect `middleware` parameter type in `Loop:addMiddleware`'s documentation.
 
 ## [0.6.2] - 2022-07-22
 ### Fixed

--- a/lib/Loop.lua
+++ b/lib/Loop.lua
@@ -491,7 +491,7 @@ end
 	Middleware added later "wraps" middleware that was added earlier. The innermost middleware function is the internal
 	function that actually calls your systems.
 	:::
-	@param middleware (nextFn: () -> (), eventName: string) -> () -> ()
+	@param middleware (nextFn: () -> ()) -> () -> ()
 ]=]
 function Loop:addMiddleware(middleware: (nextFn: () -> ()) -> () -> ())
 	table.insert(self._middlewares, middleware)


### PR DESCRIPTION
### Changes

- Fix incorrect `middleware` parameter type in `Loop:addMiddleware`'s documentation.
