### PR TITLE
Sort component list in World Inspector

### DIFF
--- a/lib/debugger/widgets/worldInspect.lua
+++ b/lib/debugger/widgets/worldInspect.lua
@@ -57,6 +57,9 @@ return function(plasma)
 					selected = debugComponent == component,
 				})
 			end
+			table.sort(items, function(a, b)
+				return a.text < b.text	
+			end)
 
 			plasma.row({ padding = 30 }, function()
 				local selectedItem = custom.selectionList(items, {


### PR DESCRIPTION
When inspecting Worlds with large amount of unique components, it can take some time to drill into the component you are looking to inspect further. Usually there is a specific component name in mind. Sorting the list by component name would improve my workflow a ton.

Before this change, the order of components was non-deterministic and would sometimes jump around when new components were added/removed. Now the list will remain static.

Before:
![image](https://github.com/evaera/matter/assets/5725602/0b8e6a7b-e75b-4356-b71e-44d316ec288e)

After: 
![image](https://github.com/evaera/matter/assets/5725602/802d80c4-c6eb-46bb-b0a8-5cbdf24422b5)

