### PR TITLE
Allow debugger states views to be toggled like systems

### DIFF
--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -94,16 +94,24 @@ local function ui(debugger, loop)
 
 			if selectedState then
 				if selectedState.isWorld then
-					debugger.debugWorld = selectedState.object
-					setWorldViewOpen(true)
+					if worldViewOpen and debugger.debugWorld == selectedState.object then
+						debugger.debugWorld = nil
+						setWorldViewOpen(false)
+					else
+						debugger.debugWorld = selectedState.object
+						setWorldViewOpen(true)
+					end
 				else
+					local previousFirstValue = if objectStack[1] then objectStack[1].value else nil
 					table.clear(objectStack)
 
-					objectStack[1] = {
-						key = selectedState.text,
-						icon = selectedState.icon,
-						value = selectedState.object,
-					}
+					if selectedState.object ~= previousFirstValue then
+						objectStack[1] = {
+							key = selectedState.text,
+							icon = selectedState.icon,
+							value = selectedState.object,
+						}
+					end
 				end
 			end
 


### PR DESCRIPTION
Addresses #51

Outcome:
Clicking on a states entry twice will close it again. This behavior is consistent with clicking on a system entry below.

https://github.com/evaera/matter/assets/5725602/89d64513-7643-4151-bff3-3ebe4dd629c1


