### PR TITLE
Replaced return statement with continue

### DIFF
--- a/example/src/server/systems/updateTransforms.lua
+++ b/example/src/server/systems/updateTransforms.lua
@@ -49,7 +49,7 @@ local function updateTransforms(world)
 		-- Despawn models that fall into the void
 		if currentCFrame.Y < -400 then
 			world:despawn(id)
-			return
+			continue
 		end
 
 		if currentCFrame ~= existingCFrame then


### PR DESCRIPTION
The use of `return` instead of `continue` results in only one model being despawned per system run.