### PR TITLE
Add loop parameter names

### DIFF
--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -103,6 +103,20 @@ Debugger.__index = Debugger
 ]=]
 
 --[=[
+	@prop loopParameterNames {string}
+	@within Debugger
+
+	Create this property in Debugger to specify the names of the parameters to your Loop constructor. This is used to
+	display a more accurate name in the debugger.
+
+	If not specified, the default behavior is to label Worlds as "World" and tables as "table", followed by its index.
+
+	```lua
+	debugger.loopParameterNames = {"World", "State", "Widgets"}
+	```
+]=]
+
+--[=[
 	Creates a new Debugger.
 
 	You need to depend on [Plasma](https://eryn.io/plasma/) in your project and pass a handle to it here.
@@ -136,6 +150,7 @@ function Debugger.new(plasma)
 	local self = setmetatable({
 		plasma = plasma,
 		loop = nil,
+		loopParameterNames = {},
 		enabled = false,
 		_windowCount = 0,
 		_queries = {},

--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -81,8 +81,10 @@ local function ui(debugger, loop)
 				local selected = (#objectStack > 0 and object == objectStack[#objectStack].value)
 					or (debugger.debugWorld == object and worldViewOpen)
 
+				local name = debugger.loopParameterNames[index]
+
 				table.insert(items, {
-					text = (if isWorld then "World" else "table") .. " " .. index,
+					text = if name then name else (if isWorld then "World" else "table") .. " " .. index,
 					icon = if isWorld then "🌐" else "{}",
 					object = object,
 					selected = selected,


### PR DESCRIPTION
Adds an extra field to the Debugger called `loopParameterNames` to specify the names you want displayed in the Matter debugger, rather than the default `World 1`, `table 2`, `table 3`, etc.