### PR TITLE
Check for entity existence before displaying hover inspect

### DIFF
--- a/lib/debugger/widgets/hoverInspect.lua
+++ b/lib/debugger/widgets/hoverInspect.lua
@@ -4,6 +4,8 @@ local FormatMode = formatTableModule.FormatMode
 
 return function(plasma)
 	return plasma.widget(function(world, id, custom)
+		if not world:contains(id) then return end
+			
 		local entityData = world:_getEntity(id)
 
 		local str = "Entity " .. id .. "\n\n"


### PR DESCRIPTION
Hovering over an entity as it's been destroyed can cause an error. This fixes that error.

```
03:58:19.233  ReplicatedStorage.rbxts_include.node_modules.@rbxts.matter.lib.World:89: attempt to index nil with nil
ReplicatedStorage.rbxts_include.node_modules.@rbxts.matter.lib.World:89 function _getEntity
ReplicatedStorage.rbxts_include.node_modules.@rbxts.matter.lib.debugger.widgets.hoverInspect:7
  -  Server
  03:58:19.233  Stack Begin  -  Studio
  ```