### PR TITLE
Fix system widgets not appearing sometimes

### DIFF
--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -272,6 +272,7 @@ local function ui(debugger, loop)
 				end
 			end
 
+			plasma.useKey(nil)
 			debugger.frame = custom.frame()
 		end, {
 			marginTop = 46,


### PR DESCRIPTION
We reset the Plasma key to nil to prevent the widget from re-rendering
Fixes #72 