### PR TITLE
Add check for config

### DIFF
--- a/lib/debugger/hookWidgets.lua
+++ b/lib/debugger/hookWidgets.lua
@@ -34,7 +34,10 @@ local dummyHandles = {
 	},
 
 	slider = function(config)
-		return config.initial or 0
+		if type(config) == "table" then
+			config = config.initial
+		end
+		return config
 	end,
 
 	window = {


### PR DESCRIPTION
Fixes the issue where it errors when you are only passing a number to debug widgets' slider. With this change, it will now check whether config is a table before indexing into initial. 