### PR TITLE
Fixed loop scheduling

### DIFF
--- a/lib/Loop.lua
+++ b/lib/Loop.lua
@@ -244,7 +244,7 @@ local function orderSystemsByDependencies(unscheduledSystems: { System })
 	local scheduledSystemsSet = {}
 	local scheduledSystems = {}
 
-	local visited, explored = 1,2
+	local visited, explored = 1, 2
 
 	local function scheduleSystem(system)
 		scheduledSystemsSet[system] = visited
@@ -253,8 +253,12 @@ local function orderSystemsByDependencies(unscheduledSystems: { System })
 			for _, dependency in system.after do
 				if scheduledSystemsSet[dependency] == nil then
 					scheduleSystem(dependency)
-				elseif scheduledSystemsSet[dependency] == visited then 
-					error(`Unable to schedule systems due to cyclic dependency between: \n{systemName(system)} \nAND \n{systemName(dependency)}`)
+				elseif scheduledSystemsSet[dependency] == visited then
+					error(
+						`Unable to schedule systems due to cyclic dependency between: \n{systemName(system)} \nAND \n{systemName(
+							dependency
+						)}`
+					)
 				end
 			end
 		end
@@ -263,7 +267,6 @@ local function orderSystemsByDependencies(unscheduledSystems: { System })
 
 		table.insert(scheduledSystems, system)
 	end
-
 
 	for _, system in sortedUnscheduledSystems do
 		if scheduledSystemsSet[system] == nil then

--- a/lib/Loop.lua
+++ b/lib/Loop.lua
@@ -132,7 +132,9 @@ type System = (...any) -> () | { system: (...any) -> (), event: string?, priorit
 ]=]
 function Loop:scheduleSystems(systems: { System })
 	for _, system in ipairs(systems) do
-		table.insert(self._systems, system)
+		if table.find(self._systems, system) == nil then
+			table.insert(self._systems, system)
+		end
 		self._systemState[system] = {}
 
 		if RunService:IsStudio() then
@@ -143,7 +145,6 @@ function Loop:scheduleSystems(systems: { System })
 
 	self:_sortSystems()
 end
-
 --[=[
 	Schedules a single system. This is an expensive function to call multiple times. Instead, try batch scheduling
 	systems with [Loop:scheduleSystems] if possible.


### PR DESCRIPTION
There are two problems with the current loop scheduler. The first being that the order of systems after the initial table.sort was non-deterministic. The second being that the logic for cycle detection was incorrect. 

To solve the first problem I switched the "_systems" table from a set to a list. Switching it to a list should not have that big of an impact on performance as games will most likely not have more than a few hundred systems (if that). I also added logic to handle the case where system names are equal -  in that case we simply fall back to the original unordered list systems effectively relying on the order provided by the user. 

The second problem came up when we had a system with dependencies on other systems. If the initial `table.sort` call returned an order such that this system (the system with dependencies on other systems) appeared first in the list the cycle detection logic would incorrectly error. For example if we had three systems, systemA, systemB, and systemC, and systemA had a dependency on systemB. If the initial sorting returned an order such that systemA appears first, systemB appears second and systemC appears last then by the time systemB is to be scheduled it would see that systemA is still in the explore phase and throw an error for a cycle which is incorrect.

I overhauled the scheduling logic to use a more straightforward approach - recursive DFS with colors or phases in this implementation. 

Closes #92 