### PR TITLE
Example packages regression fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ luac.out
 *.hex
 
 DevPackages
+/*/Packages
 roblox.toml
 build
 *.rbxl

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ luac.out
 *.hex
 
 DevPackages
-/*/Packages
+Packages
 roblox.toml
 build
 *.rbxl

--- a/example.project.json
+++ b/example.project.json
@@ -28,7 +28,7 @@
         "$path": "example/assets/assets.rbxm"
       },
       "Lib": {
-        "$path": "Packages",
+        "$className": "Folder",
         "Matter": {
           "$path": "lib"
         }


### PR DESCRIPTION
Building game currently doesn't work, as it tries to put packages which are now dev-dependencies as the root of the Matter lib.

![image](https://github.com/evaera/matter/assets/68000848/e2a106c8-f8a4-4565-b08d-6799850e69f2)

This is a regression from #89 

Right now the most straightforward fix is just keeping "Lib" as a folder with Matter. However we could also just remove Lib as a folder and have Matter directly under ReplicatedStorage, however that would require us to change every path that depends on Matter/*. 
